### PR TITLE
Support for GLSL 300 ES Shaders

### DIFF
--- a/src/WGLProgram.ts
+++ b/src/WGLProgram.ts
@@ -1,7 +1,7 @@
 
 import { WGLBuffer } from "./WGLBuffer";
 import { WGLTexture } from "./WGLTexture";
-import { WebGLAnyRenderingContext } from "./utils";
+import { isWebGL2Ctx, WebGLAnyRenderingContext } from "./utils";
 
 /**
  * @module wgl/WebGLProgram
@@ -115,7 +115,12 @@ class WGLProgram {
         vertex_shader_src = vertex_shader_src.split('\n').map(remove_comments).join('\n');
         fragment_shader_src = fragment_shader_src.split('\n').map(remove_comments).join('\n');
 
-        for (const match of vertex_shader_src.matchAll(/attribute +([\w ]+?) +([\w_]+);[\s]*$/mg)) {
+
+        // in WebGL2 shaders (gl 300 es), attribute just become the keyword 'in'
+        let vtx_shader_match = isWebGL2Ctx(this.gl) ? 
+            /in +([\w ]+?) +([\w_]+);[\s]*$/mg : /attribue +([\w ]+?) +([\w_]+);[\s]*$/mg
+
+        for (const match of vertex_shader_src.matchAll(vtx_shader_match)) {
             const [full_match, type, a_name] = match;
             this.attributes[a_name] = {'type': type, 'location': gl.getAttribLocation(this.prog, a_name)};
         }

--- a/src/WGLProgram.ts
+++ b/src/WGLProgram.ts
@@ -123,7 +123,7 @@ class WGLProgram {
 		}
 
         // in WebGL2 shaders (gl 300 es), attribute just become the keyword 'in'
-        let vtx_shader_match = isWebGL2Ctx(this.gl) ? 
+        let vtx_shader_match = is_webgl2 ? 
             /\b(?:in|attribute)+([\w ]+?) +([\w_]+);[\s]*$/mg : /attribue +([\w ]+?) +([\w_]+);[\s]*$/mg
 
         for (const match of vertex_shader_src.matchAll(vtx_shader_match)) {

--- a/src/WGLProgram.ts
+++ b/src/WGLProgram.ts
@@ -115,10 +115,16 @@ class WGLProgram {
         vertex_shader_src = vertex_shader_src.split('\n').map(remove_comments).join('\n');
         fragment_shader_src = fragment_shader_src.split('\n').map(remove_comments).join('\n');
 
+		// safety check the vertex shader source
+		const is_webgl2 = isWebGL2Ctx(this.gl);
+		if (!is_webgl2 && 
+			(vertex_shader_src.includes('#version 300 es') || fragment_shader_src.includes('#version 300 es'))) {
+			throw `WebGL2 context required for shader source containing '#version 300 es'`;
+		}
 
         // in WebGL2 shaders (gl 300 es), attribute just become the keyword 'in'
         let vtx_shader_match = isWebGL2Ctx(this.gl) ? 
-            /in +([\w ]+?) +([\w_]+);[\s]*$/mg : /attribue +([\w ]+?) +([\w_]+);[\s]*$/mg
+            /\b(?:in|attribute)+([\w ]+?) +([\w_]+);[\s]*$/mg : /attribue +([\w ]+?) +([\w_]+);[\s]*$/mg
 
         for (const match of vertex_shader_src.matchAll(vtx_shader_match)) {
             const [full_match, type, a_name] = match;


### PR DESCRIPTION
In GLSL 300 ES shaders, the 'attribute' and 'varying' keywords have been changed to 'in' or 'out', depending on if it's a vertex or fragment shader. Since 'attribute' isn't used, the WGLProgram compilation would fail to bind. I was wanting to mess with some more modern shader features, but ran into this as a road block to doing so.

This change fixes this by checking if it's a WebGL2 context, checking for the presence of a shader version string, and seting the RegEx accordingly. I've tested this using GLSL 300 ES versions of the contour fill shaders in autumnplot-gl. I'll include them here so that you can double check/test before merging. Additionally, this produces a sane error message if you attempt to use a GLSL 300 ES shader inside of a WebGL 1.0 context. 

vertex:
```
#version 300 es
uniform mat4 u_matrix;

in vec2 a_pos;
in vec2 a_tex_coord;

out highp vec2 v_tex_coord;

void main() {
    gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);
    v_tex_coord = a_tex_coord;
}
```


fragment:
```
#version 300 es
in highp vec2 v_tex_coord;

uniform sampler2D u_fill_sampler;
uniform sampler2D u_cmap_sampler;
uniform sampler2D u_cmap_nonlin_sampler;
uniform highp float u_cmap_min;
uniform highp float u_cmap_max;
uniform highp float u_opacity;
uniform int u_n_index;

out highp vec4 fragColor;

void main() {
    lowp float index_buffer = 1. / (2. * float(u_n_index));
    highp float fill_val = texture(u_fill_sampler, v_tex_coord).r;
    lowp float normed_val = (fill_val - u_cmap_min) / (u_cmap_max - u_cmap_min);
    
    if (normed_val < 0.0 || normed_val > 1.0) {
        discard;
    }

    normed_val = index_buffer + normed_val * (1. - 2. * index_buffer); // Chop off the half pixels on either end of the texture
    highp float nonlin_val = texture(u_cmap_nonlin_sampler, vec2(normed_val, 0.5)).r;
    lowp vec4 color = texture(u_cmap_sampler, vec2(nonlin_val, 0.5));
    color.a = color.a * u_opacity;
    fragColor = color;
}
```